### PR TITLE
Add user ability to customize table columns width

### DIFF
--- a/src/main/java/com/databasepreservation/common/api/v1/CollectionResource.java
+++ b/src/main/java/com/databasepreservation/common/api/v1/CollectionResource.java
@@ -319,6 +319,30 @@ public class CollectionResource implements CollectionService {
     return true;
   }
 
+  @Override
+  public Boolean updateCollectionCustomizeProperties(String databaseUUID, String collectionUUID,
+    CollectionStatus status) {
+    ControllerAssistant controllerAssistant = new ControllerAssistant() {};
+
+    LogEntryState state = LogEntryState.SUCCESS;
+    User user = new User();
+
+    try {
+      user = controllerAssistant.checkRoles(request);
+      ParameterSanitization.sanitizePath(databaseUUID, "Invalid databaseUUID");
+      ViewerFactory.getConfigurationManager().updateCollectionCustomizeProperties(databaseUUID, status);
+    } catch (ViewerException | AuthorizationException | IllegalArgumentException | IllegalAccessException
+      | GenericException e) {
+      state = LogEntryState.FAILURE;
+      throw new RESTException(e);
+    } finally {
+      // register action
+      controllerAssistant.registerAction(user, state, ViewerConstants.CONTROLLER_DATABASE_ID_PARAM, databaseUUID);
+    }
+
+    return true;
+  }
+
   /*******************************************************************************
    * Collection Resource - Config Sub-resource - Denormalization Sub-resource
    ******************************************************************************/

--- a/src/main/java/com/databasepreservation/common/client/common/visualization/browse/table/TablePanel.java
+++ b/src/main/java/com/databasepreservation/common/client/common/visualization/browse/table/TablePanel.java
@@ -218,8 +218,13 @@ public class TablePanel extends RightPanel implements ICollectionStatusObserver,
     UserLogin.getInstance().getAuthenticatedUser(new DefaultAsyncCallback<User>() {
       @Override
       public void onSuccess(User user) {
-        if (user.isAdmin() && ApplicationType.getType().equals(ViewerConstants.APPLICATION_ENV_SERVER)) {
-          buildMenu();
+
+        if (ApplicationType.getType().equals(ViewerConstants.APPLICATION_ENV_SERVER)) {
+          if (user.isAdmin()) {
+            buildMenuAdmin();
+          } else if (!user.isGuest()) {
+            buildMenuUser();
+          }
         } else if (ApplicationType.getType().equals(ViewerConstants.APPLICATION_ENV_DESKTOP)) {
           advancedOptions.remove(configurationMenu);
           Button columnsManagementBtn = new Button(messages
@@ -251,7 +256,7 @@ public class TablePanel extends RightPanel implements ICollectionStatusObserver,
     tableSearchPanel.provideSource(database, table);
   }
 
-  private void buildMenu() {
+  private void buildMenuAdmin() {
     MenuBar configurationSubMenuBar = new MenuBar(true);
     MenuItem columnMenuItem = new MenuItem(
       SafeHtmlUtils.fromString(
@@ -265,6 +270,18 @@ public class TablePanel extends RightPanel implements ICollectionStatusObserver,
     if (ApplicationType.getType().equals(ViewerConstants.APPLICATION_ENV_SERVER)) {
       configurationSubMenuBar.addItem(dataTransformationMenuItem);
     }
+    configurationMenu.addItem(SafeHtmlUtils.fromString(messages.advancedConfigurationLabelForMainTitle()),
+      configurationSubMenuBar);
+    configurationMenu.setStyleName("btn btn-link");
+  }
+
+  private void buildMenuUser() {
+    MenuBar configurationSubMenuBar = new MenuBar(true);
+    MenuItem columnMenuItem = new MenuItem(
+      SafeHtmlUtils.fromString(
+        messages.dataTransformationBtnManageTable(collectionStatus.getTableStatus(table.getUuid()).getCustomName())),
+      () -> HistoryManager.gotoColumnsManagement(database.getUuid(), table.getId()));
+    configurationSubMenuBar.addItem(columnMenuItem);
     configurationMenu.addItem(SafeHtmlUtils.fromString(messages.advancedConfigurationLabelForMainTitle()),
       configurationSubMenuBar);
     configurationMenu.setStyleName("btn btn-link");

--- a/src/main/java/com/databasepreservation/common/client/services/CollectionService.java
+++ b/src/main/java/com/databasepreservation/common/client/services/CollectionService.java
@@ -10,7 +10,6 @@ package com.databasepreservation.common.client.services;
 import java.util.List;
 import java.util.function.Consumer;
 
-import com.databasepreservation.common.api.v1.utils.JobResponse;
 import org.fusesource.restygwt.client.DirectRestService;
 import org.fusesource.restygwt.client.MethodCallback;
 import org.fusesource.restygwt.client.REST;
@@ -21,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.databasepreservation.common.api.v1.utils.JobResponse;
 import com.databasepreservation.common.api.v1.utils.StringResponse;
 import com.databasepreservation.common.client.ViewerConstants;
 import com.databasepreservation.common.client.common.DefaultMethodCallback;
@@ -95,6 +95,12 @@ public interface CollectionService extends DirectRestService {
   @RequestMapping(path = "/{databaseUUID}/collection/{collectionUUID}/config", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "Updates the internal collection configuration")
   Boolean updateCollectionConfiguration(@PathVariable(name = "databaseUUID") String databaseUUID,
+    @PathVariable(name = "collectionUUID") String collectionUUID,
+    @Parameter(name = "collectionStatus", required = true) @RequestBody CollectionStatus status);
+
+  @RequestMapping(path = "/{databaseUUID}/collection/{collectionUUID}/customize", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(summary = "Updates the internal collection configuration's customization properties")
+  Boolean updateCollectionCustomizeProperties(@PathVariable(name = "databaseUUID") String databaseUUID,
     @PathVariable(name = "collectionUUID") String collectionUUID,
     @Parameter(name = "collectionStatus", required = true) @RequestBody CollectionStatus status);
 

--- a/src/main/java/com/databasepreservation/server/client/main/MainPanel.java
+++ b/src/main/java/com/databasepreservation/server/client/main/MainPanel.java
@@ -314,7 +314,7 @@ public class MainPanel extends Composite {
       UserLogin.getInstance().getAuthenticatedUser(new DefaultAsyncCallback<User>() {
         @Override
         public void onSuccess(User user) {
-          if (user.isAdmin()) {
+          if (!user.isGuest()) {
             final String databaseUUID = currentHistoryPath.get(1);
             Sidebar sidebar = ColumnsManagementSidebar.getInstance(databaseUUID);
             if (currentHistoryPath.size() == 2) {

--- a/src/main/resources/config/dbvtk-roles.properties
+++ b/src/main/resources/config/dbvtk-roles.properties
@@ -44,6 +44,8 @@ roles.com.databasepreservation.common.api.v1.CollectionResource.run=administrato
 roles.com.databasepreservation.common.api.v1.CollectionResource.saveSavedSearch=administrators
 roles.com.databasepreservation.common.api.v1.CollectionResource.saveSavedSearch=users
 roles.com.databasepreservation.common.api.v1.CollectionResource.updateCollectionConfiguration=administrators
+roles.com.databasepreservation.common.api.v1.CollectionResource.updateCollectionCustomizeProperties=administrators
+roles.com.databasepreservation.common.api.v1.CollectionResource.updateCollectionCustomizeProperties=users
 roles.com.databasepreservation.common.api.v1.CollectionResource.updateSavedSearch=administrators
 roles.com.databasepreservation.common.api.v1.CollectionResource.updateSavedSearch=users
 ################################################


### PR DESCRIPTION
- Adds a new endpoint accessible to non-admins that allows one to customize table properties, which in this case is only column widths.
- UI now allows users to access the table management page, showing a limited version of it that only allows one to customize column width.