### PR TITLE
No longer refresh job and database lists on attach

### DIFF
--- a/src/main/java/com/databasepreservation/common/client/common/lists/DatabaseList.java
+++ b/src/main/java/com/databasepreservation/common/client/common/lists/DatabaseList.java
@@ -234,10 +234,4 @@ public class DatabaseList extends BasicAsyncTableCell<ViewerDatabase> {
   public void selectedToCopyHtml() {
 
   }
-
-  @Override
-  protected void onAttach() {
-    super.onAttach();
-    refresh();
-  }
 }

--- a/src/main/java/com/databasepreservation/common/client/common/lists/JobList.java
+++ b/src/main/java/com/databasepreservation/common/client/common/lists/JobList.java
@@ -202,10 +202,4 @@ public class JobList extends BasicAsyncTableCell<ViewerJob> {
   public void selectedToCopyHtml() {
 
   }
-
-  @Override
-  protected void onAttach() {
-    super.onAttach();
-    refresh();
-  }
 }


### PR DESCRIPTION
Small change to prevent some elements from refreshing on access, so that users can return to the same spot on a paged table when they return to it.