### PR TITLE
Log why driver load fails

### DIFF
--- a/src/main/java/com/databasepreservation/common/server/controller/SIARDController.java
+++ b/src/main/java/com/databasepreservation/common/server/controller/SIARDController.java
@@ -321,6 +321,7 @@ public class SIARDController {
     try {
       SiardControllerHelper.setupPathToDriver(connectionParameters);
     } catch (Exception e) {
+      LOGGER.warn(e.getMessage(), e);
       throw new GenericException("Could not load the driver", e);
     }
 
@@ -1104,6 +1105,7 @@ public class SIARDController {
       try {
         SiardControllerHelper.setupPathToDriver(parameters);
       } catch (Exception e) {
+        LOGGER.warn(e.getMessage(), e);
         throw new GenericException("Could not load the driver", e);
       }
 

--- a/src/main/java/com/databasepreservation/common/server/controller/SiardControllerHelper.java
+++ b/src/main/java/com/databasepreservation/common/server/controller/SiardControllerHelper.java
@@ -48,11 +48,15 @@ import com.databasepreservation.utils.ModuleConfigurationUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Miguel Guimarães <mguimaraes@keep.pt>
  */
 public class SiardControllerHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SiardControllerHelper.class);
+
   public static String buildModuleConfigurationForSIARD(String siardVersion, String siardPath,
     TableAndColumnsParameters tableAndColumnsParameters) throws GenericException {
     try {
@@ -124,6 +128,7 @@ public class SiardControllerHelper {
     try {
       setupPathToDriver(connectionParameters);
     } catch (Exception e) {
+      LOGGER.warn(e.getMessage(), e);
       throw new GenericException("Could not load the driver", e);
     }
   }


### PR DESCRIPTION
On a Mac ARM64 I'm not able to use JDBC to create a SIARD file.  I always get "Could not load the driver" without a reason.  The reason should be logged.