### PR TITLE
TableSavedSearchPanel now has a reusable instance map

### DIFF
--- a/src/main/java/com/databasepreservation/common/client/common/visualization/browse/DatabaseSearchesPanel.java
+++ b/src/main/java/com/databasepreservation/common/client/common/visualization/browse/DatabaseSearchesPanel.java
@@ -13,6 +13,7 @@ import com.databasepreservation.common.client.common.breadcrumb.BreadcrumbPanel;
 import com.databasepreservation.common.client.common.lists.SavedSearchList;
 import com.databasepreservation.common.client.common.search.SavedSearch;
 import com.databasepreservation.common.client.common.utils.CommonClientUtils;
+import com.databasepreservation.common.client.common.visualization.browse.table.TableSavedSearchPanel;
 import com.databasepreservation.common.client.index.filter.BasicSearchFilterParameter;
 import com.databasepreservation.common.client.index.filter.Filter;
 import com.databasepreservation.common.client.models.structure.ViewerDatabase;
@@ -78,6 +79,7 @@ public class DatabaseSearchesPanel extends RightPanel {
     savedSearchList.getSelectionModel().addSelectionChangeHandler(event -> {
       SavedSearch selected = savedSearchList.getSelectionModel().getSelectedObject();
       if (selected != null) {
+        TableSavedSearchPanel.clearInstance(database, selected.getUuid());
         HistoryManager.gotoSavedSearch(selected.getDatabaseUUID(), selected.getUuid());
       }
     });

--- a/src/main/java/com/databasepreservation/common/client/common/visualization/browse/table/TableSavedSearchPanel.java
+++ b/src/main/java/com/databasepreservation/common/client/common/visualization/browse/table/TableSavedSearchPanel.java
@@ -7,6 +7,9 @@
  */
 package com.databasepreservation.common.client.common.visualization.browse.table;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.databasepreservation.common.client.common.RightPanel;
 import com.databasepreservation.common.client.common.breadcrumb.BreadcrumbPanel;
 import com.databasepreservation.common.client.common.fields.MetadataField;
@@ -14,13 +17,11 @@ import com.databasepreservation.common.client.common.search.SavedSearch;
 import com.databasepreservation.common.client.common.search.SearchInfo;
 import com.databasepreservation.common.client.common.search.TableSearchPanel;
 import com.databasepreservation.common.client.common.utils.CommonClientUtils;
-import com.databasepreservation.common.client.configuration.observer.ICollectionStatusObserver;
 import com.databasepreservation.common.client.models.status.collection.CollectionStatus;
 import com.databasepreservation.common.client.models.structure.ViewerDatabase;
 import com.databasepreservation.common.client.services.CollectionService;
 import com.databasepreservation.common.client.tools.BreadcrumbManager;
 import com.databasepreservation.common.client.tools.FontAwesomeIconManager;
-import com.databasepreservation.common.client.tools.HistoryManager;
 import com.databasepreservation.common.client.tools.ViewerJsonUtils;
 import com.databasepreservation.common.client.tools.ViewerStringUtils;
 import com.google.gwt.core.client.GWT;
@@ -37,10 +38,26 @@ import config.i18n.client.ClientMessages;
  */
 public class TableSavedSearchPanel extends RightPanel {
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
+  private static final String SEPARATOR = "/";
+  private static Map<String, TableSavedSearchPanel> instances = new HashMap<>();
 
-  public static TableSavedSearchPanel createInstance(ViewerDatabase database, String savedSearchUUID,
+  public static void clearInstance(ViewerDatabase database, String savedSearchUUID) {
+    String code = database.getUuid() + SEPARATOR + savedSearchUUID;
+    instances.remove(code);
+  }
+
+  public static TableSavedSearchPanel getInstance(ViewerDatabase database, String savedSearchUUID,
     CollectionStatus status) {
-    return new TableSavedSearchPanel(database, savedSearchUUID, status);
+
+    String code = database.getUuid() + SEPARATOR + savedSearchUUID;
+    TableSavedSearchPanel instance = instances.get(code);
+
+    if (instance == null) {
+      instance = new TableSavedSearchPanel(database, savedSearchUUID, status);
+      instances.put(code, instance);
+    }
+
+    return instance;
   }
 
   interface TableSavedSearchPanelUiBinder extends UiBinder<Widget, TableSavedSearchPanel> {

--- a/src/main/java/com/databasepreservation/desktop/client/main/MainPanelDesktop.java
+++ b/src/main/java/com/databasepreservation/desktop/client/main/MainPanelDesktop.java
@@ -199,7 +199,7 @@ public class MainPanelDesktop extends Composite {
         setContent(databaseUUID, currentHistoryPath.get(0), currentHistoryPath.get(0), new RightPanelLoader() {
           @Override
           public RightPanel load(ViewerDatabase database, CollectionStatus status) {
-            return TableSavedSearchPanel.createInstance(database, searchUUID, status);
+            return TableSavedSearchPanel.getInstance(database, searchUUID, status);
           }
         });
       } else if (currentHistoryPath.size() == 4

--- a/src/main/java/com/databasepreservation/server/client/main/MainPanel.java
+++ b/src/main/java/com/databasepreservation/server/client/main/MainPanel.java
@@ -659,7 +659,7 @@ public class MainPanel extends Composite {
               setContent(databaseUUID, currentHistoryPath.get(0), currentHistoryPath.get(0), new RightPanelLoader() {
                 @Override
                 public RightPanel load(ViewerDatabase database, CollectionStatus status) {
-                  return TableSavedSearchPanel.createInstance(database, searchUUID, status);
+                  return TableSavedSearchPanel.getInstance(database, searchUUID, status);
                 }
               });
 


### PR DESCRIPTION
- Allows saved search tables to not refresh when the panel is reopened, so that accessing and returning from a row in that search panel doesn't reset any search modifications made by the user.
- Explicitly forces a save search panel instance to be reloaded if it is accessed from the saved searches list, as users likely won't expect want to see the unmodified saved search in this use case.