### PR TITLE
Fix (TableStatus): Columns Reordering After Transformations

### DIFF
--- a/src/main/java/com/databasepreservation/common/client/models/status/collection/TableStatus.java
+++ b/src/main/java/com/databasepreservation/common/client/models/status/collection/TableStatus.java
@@ -188,6 +188,15 @@ public class TableStatus implements Serializable {
     }
   }
 
+  public boolean isNotOrdered() {
+    if (columns == null || columns.isEmpty()) {
+      return false;
+    }
+
+    return columns.stream().anyMatch(col -> col.getOrder() > columns.size());
+
+  }
+
   @JsonIgnore
   public List<ColumnStatus> getVisibleColumnsList() {
     return columns.stream().filter(c -> c.getSearchStatus().getList().isShow()).sorted().collect(Collectors.toList());

--- a/src/main/java/com/databasepreservation/common/server/ConfigurationManager.java
+++ b/src/main/java/com/databasepreservation/common/server/ConfigurationManager.java
@@ -417,6 +417,7 @@ public class ConfigurationManager {
           "Failed to validate the collection status update due to integrity violation: " + e.getMessage(), e);
       }
 
+      healCollectionStatus(updatedStatus);
       JsonTransformer.writeObjectToFile(updatedStatus, statusFile);
 
       if (updatedStatus.isNeedsToBeProcessed()) {
@@ -427,6 +428,18 @@ public class ConfigurationManager {
           ViewerDatabaseConfigurationStatus.UP_TO_DATE);
       }
     }
+  }
+
+  public void healCollectionStatus(CollectionStatus collectionStatus) {
+    // Ensure valid column orders for the tables
+    List<TableStatus> tables = collectionStatus.getTables();
+    tables.forEach(tableStatus -> {
+      if (tableStatus.isNotOrdered()) {
+        LOGGER.warn("{} needs to be reordered", tableStatus.getName());
+        tableStatus.reorderColumns();
+      }
+    });
+    collectionStatus.setTables(tables);
   }
 
   /**


### PR DESCRIPTION
After data transformations and the deletion of virtual columns, the column order wasn't being updated, resulting in an `Index Out Of Bounds` error. 

This PR fixes the issue by ensuring columns of are properly reordered whenever a table column goes out of scope.